### PR TITLE
Change test generator to read last recorded output.

### DIFF
--- a/gen/gen_tests.odin
+++ b/gen/gen_tests.odin
@@ -7,6 +7,7 @@ import "core:path/filepath"
 import "core:strings"
 
 main :: proc() {
+
     files, _ := filepath.glob("./tests/*.lang", context.temp_allocator)
 
     builder := strings.builder_make()
@@ -26,7 +27,7 @@ main :: proc() {
         strings.write_string(&builder, "@(test)\n")
         fmt.sbprintf(&builder, "translation_{} :: proc(t: ^testing.T) {{\n", s)
         fmt.sbprintf(&builder, "    f := \"{}\"\n", ff)
-        fmt.sbprintf(&builder, "    cpp := \"./tests/{}.cpp\"\n", s)
+        fmt.sbprintf(&builder, "    cpp := \"./tests/{}.cpp.out\"\n", s)
         fmt.sbprintf(
             &builder,
             "    testing.expectf(t, os.exists(cpp), \"{{}} not recorded. {{}} not found\", f, cpp)\n",

--- a/tests/fn.cpp.out
+++ b/tests/fn.cpp.out
@@ -1,0 +1,13 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+int sum(int, int);
+void ___entry___();
+
+int sum(int a, int b){
+}
+void ___entry___(){
+}
+int main(int argc, char** argv) {___entry___();}

--- a/tests/fn_call.cpp.out
+++ b/tests/fn_call.cpp.out
@@ -1,0 +1,11 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+void ___entry___();
+
+void ___entry___(){
+puts("Hello, World");
+}
+int main(int argc, char** argv) {___entry___();}

--- a/tests/import.cpp.out
+++ b/tests/import.cpp.out
@@ -1,0 +1,12 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+extern "C" int exit(int);
+void ___entry___();
+
+void ___entry___(){
+puts("Hello World");
+}
+int main(int argc, char** argv) {___entry___();}

--- a/tests/lit.cpp.out
+++ b/tests/lit.cpp.out
@@ -1,0 +1,13 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+extern "C" int exit(int);
+void ___entry___();
+
+void ___entry___(){
+puts("Hello World");
+exit(1);
+}
+int main(int argc, char** argv) {___entry___();}

--- a/tests/std.cpp.out
+++ b/tests/std.cpp.out
@@ -1,0 +1,8 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+extern "C" int exit(int);
+
+

--- a/tests/var.cpp.out
+++ b/tests/var.cpp.out
@@ -1,0 +1,21 @@
+/* -- Builtin types -- */
+typedef const char* cstr;
+/* -- ------------- -- */
+
+extern "C" int puts(cstr);
+extern "C" int exit(int);
+void thing(bool);
+void ___entry___();
+
+void thing(bool thing){
+exit(thing);
+}
+void ___entry___(){
+int a = 10;
+cstr b = "Hello";
+bool c = true;
+bool d = false;
+puts(b);
+thing(d);
+}
+int main(int argc, char** argv) {___entry___();}


### PR DESCRIPTION
## Done

Instead of reading the current implementation's output which could only catch errors in the language files, it now reads the last implementation output to see changes in the implementation as well.