### PR TITLE
Syntax changes on variable declaration + auto cast keyword

### DIFF
--- a/tests/arith.lang
+++ b/tests/arith.lang
@@ -1,12 +1,12 @@
 import "std.lang"
 
 main :: void() {
-    i := 30 + 30
-    j := 30 - 1
-    l := 10 * 2
-    m := 2 / 2
-    p := i < j
-    g := j > l
-    k := l % 2
+    var i = 30 + 30
+    var j = 30 - 1
+    var l = 10 * 2
+    var m = 2 / 2
+    var p = i < j
+    var g = j > l
+    var k = l % 2
     exit(i)
 }

--- a/tests/block.lang
+++ b/tests/block.lang
@@ -1,7 +1,7 @@
 import "std.lang"
 
 main :: void(){
-    a := "Hello, World"
+    var a = "Hello, World"
     {
 	puts(a)
     }

--- a/tests/control_flow.lang
+++ b/tests/control_flow.lang
@@ -2,12 +2,12 @@ import "std.lang"
 
 main :: void() {
 
-    i := 0
+    var i = 0
     if i < 10 {
 	puts("Hello, World")
     }
 
-    k := 100
+    var k = 100
     if k > 10 {
 	puts("K is greater than 10")
     } else if k < 10 {
@@ -21,11 +21,11 @@ main :: void() {
 	i += 1
     }
 
-    for j := 0; j < 10; j += 1 {
+    for var j = 0; j < 10; j += 1 {
 	puts("TODO: add print number or printf support")
     }
 
-    l := 0
+    var l = 0
     while true {
 	puts("Should print 4 times")
 	if l < 3 {

--- a/tests/data.lang
+++ b/tests/data.lang
@@ -6,7 +6,7 @@ example :: void(a int*) {
 
 main :: void() {
 
-    a := 1
+    var a = 1
     putd(a)
     puts("")
     example(&a)

--- a/tests/std.lang
+++ b/tests/std.lang
@@ -5,7 +5,7 @@ extern "c" exit :: int(code int)
 
 putd :: void(d int) {
     if d > 9 {
-	a := d / 10
+	var a = d / 10
 	d -= 10 * a
 	putd(a)
     }

--- a/tests/struct.lang
+++ b/tests/struct.lang
@@ -10,9 +10,9 @@ struct Foo {
 }
 
 main :: void() {
-   foo := Foo{10, 20}
+   var foo = Foo{10, 20}
 
-   b: int = foo.baz
+   var b: int = foo.baz
 
    putd(foo.bar)
    puts("")

--- a/tests/var.lang
+++ b/tests/var.lang
@@ -5,10 +5,10 @@ thing :: void(thing bool) {
 }
 
 main :: void() {
-    a := 10
-    b := "Hello"
-    c := true
-    d := false
+    var a = 10
+    var b = "Hello"
+    var c = true
+    var d = false
     
     puts(b)
 


### PR DESCRIPTION
## Done

- Variables changed from `x := y` to `var x = y` and the typed chaned from `x : type = y` to `var x: type = y`
- Added auto cast keyword: `xx`

```odin
example :: void(x long) {

}

main :: void() {
    var x: int = 10
    example(xx x) // xx is the auto cast operator
}
```
