### PR TITLE
Dynamic array written in itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.cpp
 *.rdi
 tests.odin
+.vscode
+bug/
+build/
+raylib/

--- a/internal/builtin.lang
+++ b/internal/builtin.lang
@@ -1,10 +1,12 @@
+import "std:c"
+
 struct string {
     data ^void,
     len int,
 }
 
 builtin_make_string :: string(data ^void, len int) {
-    return string{xx data, len}
+    return string{data, len}
 }
 
 len_str :: int(str string) {
@@ -13,4 +15,38 @@ len_str :: int(str string) {
 
 to_cstring :: ^char(str string) {
     return str.data as ^char
+}
+
+struct RawDynamic {
+    items ^void,
+    cap int,
+    len int,
+}
+
+make_dyn_arr :: RawDynamic(elsize size_t) {
+    var items = malloc(1024 * elsize)
+    return RawDynamic{items, 1024, 0}
+}
+
+append_dyn_arr :: void(arr ^RawDynamic, item ^void, elsize size_t) {
+    if arr.len + 1 > arr.cap {
+	arr.cap = arr.cap * 2
+	arr.items = realloc(arr.items, arr.cap * elsize)
+    }
+    var dest: ^char = (arr.items as ^char) + (arr.len * elsize)
+    memcpy(dest, item, elsize)
+    arr.len += 1
+}
+
+// FIXME: this could return the ptr to the item itself. Maybe with `generics`
+at_dyn_arr :: ^void(arr RawDynamic, idx int, elsize size_t) {
+    return (arr.items as ^char) + (idx * elsize)
+}
+
+len_dyn_arr :: int(arr RawDynamic) {
+    return arr.len
+}
+
+destroy_dyn_arr :: void(arr RawDynamic) {
+    free(arr.items)
 }

--- a/main.odin
+++ b/main.odin
@@ -1710,6 +1710,7 @@ do_all_passes_on_file :: proc(filectx: ^FileContext, out := true) -> bool {
         return false
     }
 
+    ctx.std_mod_paths = collect_std_mods()
     deal_with_import("./internal/builtin.lang")
     transpile_file(filectx.ast)
 

--- a/tests/dyn_arr.lang
+++ b/tests/dyn_arr.lang
@@ -2,13 +2,19 @@ import "std:c"
 
 main :: void() {
     var xs = [dynamic]int{}
-    append_dynamic_array(&xs, 1)
+    var i = 0
+    append(&xs, &i)
 
     for var i = 1; i < 10; i += 1 {
-	append_dynamic_array(&xs, i)
+	append(&xs, &i)
     }
 
     for var i = 0; i < xs.len; i+=1 {
-	printf(c("%d\n"), at_dynamic_array(xs, i))
+	var a = at(xs, i) as ^int
+	printf(c("%d\n"), @a)
     }
+
+    printf(c("xs len: %d\n"), len(xs))
+
+    destroy_dyn_arr(xs)
 }

--- a/todo.md
+++ b/todo.md
@@ -54,9 +54,12 @@
     - [ ] Add `-fo` option to format cpp output with `clang-format`
 - Internal + STD
     - [x] Dynamic array
-        - [ ] Reimplement as builtin instead of c++ implementation
-        - [ ] Add builtin functions like `append` that transpiles to the dynamic version
-        - [ ] Add support for `len`
+        - [x] Reimplement as builtin instead of c++ implementation
+        - [x] Add builtin functions like `append` that transpiles to the dynamic version
+        - [x] Add support for `len`
+        - [x] At:
+            - [ ] Allow the return type to be the type of dynamic
+            - [ ] Allow use of `[]` indexing
     - [ ] Maps
     - [ ] Typeinfo
 - General


### PR DESCRIPTION
## Done

- Add builtin methods for `RawDynamic`
  - `append`, `len`, `at`
- Rewrote dynamic array in the language

## Changes

- `append_dynamic_array` -> `append`
- `at_dynamic_array` -> `at`

## Notes

- `at` return a `void*` that needs to be casted to the array type.
- `destroy_dyn_arr` should be called to free the allocated memory.